### PR TITLE
Исправлено ограничение ширины значений в панели группировки

### DIFF
--- a/siemMonkey.css
+++ b/siemMonkey.css
@@ -189,3 +189,7 @@ div.openMsgs
     transform: rotate(360deg);
   }
 }
+
+events-grouping pdql-fast-filter {
+  max-width: 100% !important;
+}


### PR DESCRIPTION
По неведомой причине один из стилей ограничивал ширину элемента с текстом 70%. Это ограничение убрано жестким хаком в CSS - явным переопределением ширины 100%.

resolves #14