### PR TITLE
add desc and link corr rules

### DIFF
--- a/options.html
+++ b/options.html
@@ -37,6 +37,11 @@
 </div>
 <br/>
 <div>
+  <input type="checkbox" id="dont_show_desc_rules" name="dont_show_desc_rules">
+  <label for="dont_show_desc_rules">Не показывать описание и ссылку на правило корреляции в Knowledge Base</label>
+</div>
+<br/>
+<div>
   <input type="checkbox" id="disable_agg_sort" name="disable_agg_sort">
   <label for="disable_agg_sort">Отключить новое поведение сортировки при аггрегации (R25.1 и выше)</label>
 </div>

--- a/options.js
+++ b/options.js
@@ -16,6 +16,7 @@
 function save_options() {
   let vt_api_key = document.getElementById('vt-api-key').value;
   let dont_show_save_event_icons = document.getElementById('dont_show_save_event_icons').checked;
+  let dont_show_desc_rules = document.getElementById('dont_show_desc_rules').checked;
   let disable_agg_sort = document.getElementById('disable_agg_sort').checked;
   let iplinks = [];
   $(".iplink").each(function(index){
@@ -33,7 +34,7 @@ function save_options() {
   });
  
 
-  let options = {vt_api_key, iplinks, hashlinks, dont_show_save_event_icons, disable_agg_sort};
+  let options = {vt_api_key, iplinks, hashlinks, dont_show_save_event_icons, dont_show_desc_rules, disable_agg_sort};
   chrome.storage.sync.set(
     {options},
     function() {
@@ -60,6 +61,13 @@ function restore_options() {
       }
       else{
         document.getElementById('dont_show_save_event_icons').checked = false;
+      }
+
+      if(items.options.hasOwnProperty('dont_show_desc_rules')){
+        document.getElementById('dont_show_desc_rules').checked = items.options['dont_show_desc_rules'];
+      }
+      else{
+        document.getElementById('dont_show_desc_rules').checked = false;
       }
 
       if(items.options.hasOwnProperty('disable_agg_sort')){

--- a/script.js
+++ b/script.js
@@ -174,16 +174,6 @@ function extractLast( term ) {
 
 let observer = new MutationObserver(async mutations => {
   for(let mutation of mutations) {
-      if(mutation.target.parentNode && mutation.target.parentNode.nodeName === 'RULES-CARD-LINK'){
-        // Вывод описание правила корреляции на вкладке "Инциденты" в правом сайдбаре
-        correlation_name = $(mutation.target.parentNode).children('span').eq(1).text();
-        $(mutation.target.parentNode).children('span').slice(2).remove();
-        let msg = await getCorrelationRuleInfoByName(correlation_name);
-        let desc = msg['description'];
-        $(mutation.target.parentNode).children('span').eq(1)
-        .after($('<span>').addClass('mc-text-light').text(` (${desc})`));
-      }
-
       if(mutation.target.parentNode && mutation.target.parentNode.nodeName === 'EVENTS-FILTER-POPOVER'){
         // ━━━━━★. *･｡ﾟ✧⁺
         if(fields.length == 0)
@@ -243,6 +233,48 @@ let observer = new MutationObserver(async mutations => {
             return false;
           }
         });
+      }
+
+      //Добавляет описание и ссылку на правило в разделе "события"
+      if(mutation.target.parentNode && mutation.target.parentNode.parentNode 
+        && mutation.target.parentNode.parentNode.nodeName === 'RULES-CARD-LINK'
+        && mutation.target.parentNode.className === 'mc-link ng-binding ng-scope'
+        && options.options.dont_show_desc_rules === false){
+          
+          let correlation_name_node = $(mutation.target.parentNode.parentNode).children('span.mc-link.ng-scope');
+          $(mutation.target.parentNode.parentNode).children('span.corr-desc').remove();
+          $(mutation.target.parentNode.parentNode).children('i.corr-link').remove();
+          
+          let correlation_name = correlation_name_node.text();
+          let msg = await getCorrelationRuleInfoByName(correlation_name);
+          let [correlation_description, correlation_link_to_ptkb] = corr_name_info(msg);
+
+          setTimeout(AddElementIfNotExist, 0, correlation_name_node, correlation_description);
+          setTimeout(AddElementIfNotExist, 0, correlation_name_node, correlation_link_to_ptkb);
+      }
+
+      //Добавляет описание и ссылку на правило в разделе "инциденты"
+      else if(mutation.target.parentNode && ((mutation.target.parentNode.parentNode 
+        && mutation.target.parentNode.parentNode.nodeName === 'RULES-CARD-LINK')
+        || mutation.target.parentNode.nodeName === 'RULES-CARD-LINK')
+        && mutation.target.className === 'mc-link ng-scope'
+        && options.options.dont_show_desc_rules === false){
+          
+          let correlation_name_node = $(mutation.target.parentNode).children('span.mc-link.ng-scope');
+          let correlation_name = correlation_name_node.text();
+          let msg = await getCorrelationRuleInfoByName(correlation_name)
+          
+          let corr_desc_old = $(mutation.target.parentNode).children('span.corr-desc').text()
+
+          if(!corr_desc_old || (corr_desc_old && msg['description'] !== corr_desc_old)){
+            $(mutation.target.parentNode).children('span.corr-desc').remove();
+            $(mutation.target.parentNode).children('i.corr-link').remove();
+
+            let [correlation_description, correlation_link_to_ptkb] = corr_name_info(msg);
+        
+            setTimeout(AddElementIfNotExist, 0, correlation_name_node, correlation_description);
+            setTimeout(AddElementIfNotExist, 0, correlation_name_node, correlation_link_to_ptkb);
+          }  
       }
 
       for(let addedNode of mutation.addedNodes) {
@@ -340,6 +372,31 @@ function getCorrelationRuleInfoByName(correlation_name)
   return request;
 }
 
+function corr_name_info(msg) 
+{
+  let description = msg['description'];
+  let objectId = msg['objectId'];
+
+  let correlation_description = $('<span>')
+  .addClass('corr-desc')
+  .addClass('mc-text-light')
+  .text(` (${description})`);
+
+  let correlation_link_to_ptkb = $('<i title="Открыть правило в Knowledge Base">')
+  .addClass('pt-icons')
+  .addClass('pt-icons-external-link_16')
+  .addClass('mc-link__icon')
+  .addClass('corr-link')
+  .css('margin-left', '4px')
+  .css('cursor', 'pointer')
+  .click(async function (){
+    let siemUrl = window.location.origin;
+    let link = `${siemUrl}:8091/#/siem/${objectId}`
+    window.open(link, "_blank");
+  });
+
+  return [correlation_description, correlation_link_to_ptkb];
+};
 
 async function getdata(siemUrl, filter, count, callback, outputelemsuffix="", ttfrom="", ttto="")
 {


### PR DESCRIPTION
Обогащение карточки события: стандартным описанием правила корреляции и прямой ссылкой на него в Knowledge base
![image](https://github.com/Security-Experts-Community/siem-monkey/assets/127760284/c2af6a71-957f-4ef6-b9f5-5747b702c289)

Данную функцию можно отключить через параметры расширения siem-monkey:
![image](https://github.com/Security-Experts-Community/siem-monkey/assets/127760284/c48cfb66-e41f-41c9-bc60-c0d55071328c)

