### PR TITLE
Change styles injection logic

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,6 @@
 			 "update.popup.js",
 			 "processTree.popup.js",
 			 "script.js"],
-			"css": ["siemMonkey.css","libs/jquery-ui-1.12.1/jquery-ui.min.monkey.css"],
 			"all_frames": true
         }
     ],
@@ -45,7 +44,7 @@
 		{
 			"resources": [
 			"img/icon128.png",
-	    	"siemMonkey.css",
+			"siemMonkey.css",
 			"customfilters.json",
 			"fieldaliases.json",
 			"xhr_override.js",

--- a/popup.css
+++ b/popup.css
@@ -26,7 +26,10 @@ body.loading .lds-dual-ring {
     display: block;
 }
 
-* { font-family:Roboto,Helvetica Neue,sans-serif; font-size:10px; }
+:not([class^="ui-datepicker"]) {
+  font-family: Roboto,Helvetica Neue,sans-serif;
+  font-size: 10px;
+}
 
 .parent {
     color: white;


### PR DESCRIPTION
Привет.
Продолжаю дробить PR.
Есть предложение немного изменить логику инъекции стилей (тогда не должно быть конфликтов на страницах, где обезьянка не используется, но расширение имеет доступ к странице и подгружает стили через манифест. Таким образом не будет необходимости вручную давать доступ расширению или отлавливать конфликты стилей):
- css убраны из манифеста
- стили загружаются после проверки того, что мы на нужной странице
- немного подправлены стили для popup-а (даты в календаре)

Thanks!